### PR TITLE
Add DNSSEC support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.12
 
 MAINTAINER resyst-it <florian.cauzardjarry@gmail.com>
 
-RUN apk --update add bind
+RUN apk --update add bind bind-dnssec-tools
 
 EXPOSE 53
 


### PR DESCRIPTION
Now there is no DNSSEC tools in container. For example, there is no dnsssec-keygen tool. 
This patch adds a DNSSEC tools installation.