### PR TITLE
Add no-cache option to the apk command.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.12
 
 MAINTAINER resyst-it <florian.cauzardjarry@gmail.com>
 
-RUN apk --update add bind bind-dnssec-tools
+RUN apk --update --no-cache add bind bind-dnssec-tools
 
 EXPOSE 53
 


### PR DESCRIPTION
Literally it's the same as to run ```rm /var/cache/apk/*``` in the end
of a Dockerfile. This option saves about 1.8Mb of an image size.